### PR TITLE
Updates to reference released dependencies

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -58,35 +58,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Create local deps folder
-        run: mkdir -p deps
-
-      - name: Copy client common wheel
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: ci_cd.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-common-wheel
-          path: deps
-          repo: pyansys/openapi-common
-          check_artifacts: false
-          search_artifacts: false
-
-      - name: Copy client library
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: build_and_test_library.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-bomanalytics-openapi-wheel
-          path: deps
-          repo: pyansys/grantami-bomanalytics-openapi
-          check_artifacts: false
-          search_artifacts: false
-
       - name: Install style requirements
         run: pip install tox --disable-pip-version-check
 
@@ -110,36 +81,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Create local deps folder
-        run: |
-          mkdir -p deps
-
-      - name: Copy client common wheel
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: ci_cd.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-common-wheel
-          path: deps
-          repo: pyansys/openapi-common
-          check_artifacts: false
-          search_artifacts: false
-
-      - name: Copy client library
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: build_and_test_library.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-bomanalytics-openapi-wheel
-          path: deps
-          repo: pyansys/grantami-bomanalytics-openapi
-          check_artifacts: false
-          search_artifacts: false
 
       - name: Install dependencies
         run: pip install tox tox-gh-actions==2.9.1 --disable-pip-version-check
@@ -174,35 +115,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-
-      - name: Create local deps folder
-        run: mkdir -p deps
-
-      - name: Copy client common wheel
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: ci_cd.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-common-wheel
-          path: deps
-          repo: pyansys/openapi-common
-          check_artifacts: false
-          search_artifacts: false
-
-      - name: Copy client library
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: build_and_test_library.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-bomanalytics-openapi-wheel
-          path: deps
-          repo: pyansys/grantami-bomanalytics-openapi
-          check_artifacts: false
-          search_artifacts: false
 
       - name: Install dependencies
         run: pip install tox tox-gh-actions==2.9.1 --disable-pip-version-check
@@ -273,37 +185,8 @@ jobs:
       - name: Install pandoc
         run: sudo apt install pandoc
 
-      - name: Create local deps folder
-        run: mkdir -p deps
-
-      - name: Copy client common wheel
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: ci_cd.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-common-wheel
-          path: deps
-          repo: pyansys/openapi-common
-          check_artifacts: false
-          search_artifacts: false
-
-      - name: Copy client library
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.CLIENT_COMMON_REPO_TOKEN}}
-          workflow: build_and_test_library.yml
-          workflow_conclusion: success
-          branch: main
-          name: ansys-grantami-bomanalytics-openapi-wheel
-          path: deps
-          repo: pyansys/grantami-bomanalytics-openapi
-          check_artifacts: false
-          search_artifacts: false
-
       - name: Install library
-        run: pip install .[doc] --find-links ./deps --disable-pip-version-check --pre
+        run: pip install .[doc] --disable-pip-version-check
 
       - name: Set BUILD_EXAMPLES environment variable
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
@@ -398,7 +281,7 @@ jobs:
       - name: Upload to Azure PyPi (disabled)
         run: |
           pip install twine
-          # twine upload --skip-existing ./**/*.whl
+          twine upload --non-interactive --skip-existing ~/**/*.whl
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: __token__

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -278,13 +278,13 @@ jobs:
           CLEAN: true
 
       # note how we use the PyPI tokens
-      - name: Upload to PyPi
+      - name: Upload to PyPI
         run: |
           pip install twine
           twine upload --non-interactive --skip-existing ~/**/*.whl
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -278,7 +278,7 @@ jobs:
           CLEAN: true
 
       # note how we use the PyPI tokens
-      - name: Upload to Azure PyPi (disabled)
+      - name: Upload to PyPi
         run: |
           pip install twine
           twine upload --non-interactive --skip-existing ~/**/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 ]
 classifiers = [
   "License :: OSI Approved :: MIT License",
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering :: Information Analysis",
   "Operating System :: Microsoft :: Windows",
@@ -29,7 +29,6 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
-  "Private :: Do Not Upload"
 ]
 packages = [
   { include = "**/*.py", from = "src" }
@@ -40,8 +39,8 @@ python = "^3.7"
 
 # Packages for core library
 importlib_metadata = { version = ">=1.0", python  = "<3.8" }  # Granta MI STK requires 3.4.0
-ansys-openapi-common = "*"  # TODO: Change to the released version
-ansys-grantami-bomanalytics-openapi = "*"  # TODO: Change to the released version
+ansys-openapi-common = "< 2.0.0"
+ansys-grantami-bomanalytics-openapi = "1.0.0"
 
 # Common packages for test, examples, and docs
 jupyterlab = { version = "3.2.8", optional = true }
@@ -118,7 +117,6 @@ python =
 [testenv]
 deps =
   .[test]
-install_command = pip install --pre --find-links ./deps {opts} {packages}
 commands = pytest --cov=ansys.grantami.bomanalytics --cov-report=xml {posargs}
 passenv =
     TEST_SL_URL
@@ -131,7 +129,6 @@ deps =
     flake8==3.9.2
     black
     mypy==0.910
-install_command = pip install --pre --find-links ./deps {opts} {packages}
 commands =
     codespell ./src ./tests ./examples ./doc/source
     flake8 ./src ./tests ./examples


### PR DESCRIPTION
Closes #47 

This PR updates the CI/CD and pyproject.toml files to reference release versions of packages. Also removes `download-artifact` actions and enables twine upload for releases.

The dependencies are set as follows:

- openapi-common has a `<2.0.0` dependency. i.e. this package will work with any openapi-common that exposes a compatible interface
- bomanalytics-openapi has a `==1.0.0` dependency, i.e. an exact dependency. Multiple versions of this package could depend on bomanalytics-openapi 1.0.0, but if we ever want to bump bomanalytics-openapi, we will be forced to release a new version of grantami-bomanalytics