### PR TITLE
Bump minimum Python patch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.7.1"
 
 # Packages for core library
 importlib_metadata = { version = ">=1.0", python  = "<3.8" }  # Granta MI STK requires 3.4.0


### PR DESCRIPTION
This PR closes #127 

Dependabot is erroring because the advertised package Python compatibility is incompatible with pandas. We support 3.7.0 and up, whereas pandas supports 3.7.1 and up. The change here aligns these requirements.