### PR TITLE
CI - Skip integration tests on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    labels:
-      - "maintenance"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Skip integration tests when dependabot generates PRs