### PR TITLE
Fix PyPI Documentation Links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,8 @@ Alternatively, clone and install with:
 
 Documentation
 -------------
-`PyAnsys <https://grantami.docs.pyansys.com>`_
+See `Granta MI BoM Analytics Documentation <https://grantami.docs.pyansys.com>`_
+for more details.
 
 
 Usage
@@ -44,7 +45,7 @@ Here's a brief example of how the package works:
 
     >>> from pprint import pprint
     >>> from ansys.grantami.bomanalytics import Connection, queries
-    >>> cxn = Connection(servicelayer_url='http://localhost/mi_servicelayer').with_autologon().connect()
+    >>> cxn = Connection("http://my_grantami_server/mi_servicelayer").with_autologon().connect()
     >>> query = (
     ...     queries.MaterialImpactedSubstancesQuery()
     ...     .with_material_ids(['plastic-abs-pvc-flame'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ license = "MIT"
 authors = ["ANSYS, Inc."]
 maintainers = ["PyAnsys Maintainers <pyansys.maintainers@ansys.com>"]
 repository = "https://github.com/pyansys/grantami-bomanalytics"
+documentation = "https://grantami.docs.pyansys.com"
 readme = "README.rst"
 keywords = [
   "Ansys",


### PR DESCRIPTION
Closes #157 

This PR adds some more context to the documentation link in the README, which ends up on PyPI. It also adds a documentation tag to the pyproject.toml, to ensure the documentation link is added to the sidebar on PyPI.

Closes #125

Also shorten the long line in the quick code section by removing the keyword.