### PR TITLE
[CI]156 - Add generate_release_notes flag to release

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
+          generate_release_notes: true
           files: |
             ~/**/*.whl
             ./**/*.zip


### PR DESCRIPTION
Closes #156 

Add the `generate_release_flag` argument to the release action. This will automatically summarise contributions to a release on the github releases page.