### PR TITLE
Allow manual integration tests

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -17,6 +17,7 @@ on:
         required: true
       TEST_SERVER_READ_PASS:
         required: true
+  workflow_dispatch:
 
 concurrency:
   group: integration-server


### PR DESCRIPTION
This PR allows manual execution of integration tests.

This will be useful for dependabot PRs where we want to manually check that integration tests complete successfully, such as for https://github.com/pyansys/grantami-bomanalytics/pull/162