### PR TITLE
Add dummy examples

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -204,8 +204,11 @@ epub_exclude_files = ["search.html"]
 cwd = Path(os.getcwd())
 assert (cwd.name == "source")
 EXAMPLES_DIR_NAME = "examples"
+DUMMY_EXAMPLES_DIR_NAME = "examples-dummy"
+
 examples_output_dir = Path(EXAMPLES_DIR_NAME).absolute()
 examples_source_dir = Path("../../" + EXAMPLES_DIR_NAME).absolute()
+dummy_examples_source_dir = Path("../../" + DUMMY_EXAMPLES_DIR_NAME).absolute() / Path(EXAMPLES_DIR_NAME)
 EXAMPLE_FLAG = os.getenv("BUILD_EXAMPLES")
 
 # If we are building examples, use the included ipython-profile
@@ -241,11 +244,8 @@ if not examples_output_dir.is_dir():
 
     # If we are skipping examples in the docs, create a placeholder index.rst file to avoid sphinx errors.
     else:
-        print("'BUILD_EXAMPLES' environment variable is not set, skipping examples.")
-        examples_output_dir.mkdir(parents=False, exist_ok=False)
-        example_index = examples_output_dir / Path("index.rst")
-        with open(example_index, "w") as f:
-            f.write("Example Scripts\n===============\n\nExample build skipped")
+        print("'BUILD_EXAMPLES' environment variable is not set, using standalone examples.")
+        _copy_examples_and_convert_to_notebooks(dummy_examples_source_dir, examples_output_dir)
 
 
 nbsphinx_prolog = """

--- a/examples-dummy/examples/0_Test_module_import.py
+++ b/examples-dummy/examples/0_Test_module_import.py
@@ -1,0 +1,35 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.13.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# # Test Notebook 1
+
+# Check we can import the Connection class and instantiate some things
+
+# + tags=[]
+from ansys.grantami.bomanalytics import Connection
+
+server_url = "http://my_grantami_server/mi_servicelayer"
+cxn = Connection(server_url)
+cxn
+# -
+
+# Also try an indicator
+
+# + tags=[]
+from ansys.grantami.bomanalytics.indicators import RoHSIndicator
+
+indicator = RoHSIndicator(name="Indicator", legislation_names=["Legislation"])
+indicator
+# -

--- a/examples-dummy/examples/1_Test_Example/1-1_Test_other_features.py
+++ b/examples-dummy/examples/1_Test_Example/1-1_Test_other_features.py
@@ -1,0 +1,46 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:light
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.13.1
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# # Other Features
+
+# ## Double-backticks
+
+# This renders as a class: ``ansys.grantami.bomanalytics.Connection``.
+
+# ## Hyperlinks
+
+# This is an internal hyperlink [Parent page](../index.rst).
+# This is an external hyperlink [Google](https://google.com).
+# This is a link to a file [File](supporting-file.txt)
+
+# ## Unordered list
+
+# Here's an unordered list
+#
+# - Bread
+# - Cheese
+# - Butter
+
+# ## Dataframes
+
+# Here's a Pandas dataframe
+
+# + tags=[]
+import pandas as pd
+import numpy as np
+
+df = pd.DataFrame(np.random.rand(10, 10))
+df.head()
+# -

--- a/examples-dummy/examples/1_Test_Example/index.rst
+++ b/examples-dummy/examples/1_Test_Example/index.rst
@@ -1,0 +1,11 @@
+.. _ref_grantami_bomanalytics_test_other_features:
+
+Test Other Features
+===================
+
+This notebook tests other key features of the example notebooks.
+
+.. toctree::
+   :maxdepth: 1
+
+   1-1_Test_other_features

--- a/examples-dummy/examples/1_Test_Example/supporting-file.txt
+++ b/examples-dummy/examples/1_Test_Example/supporting-file.txt
@@ -1,0 +1,1 @@
+Test file

--- a/examples-dummy/examples/index.rst
+++ b/examples-dummy/examples/index.rst
@@ -1,0 +1,16 @@
+.. _ref_grantami_bomanalytics_test_examples:
+
+Example Scripts
+===============
+
+Example build skipped
+
+The examples below are to validate the Jupyter notebook to HTML conversion.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   0_Test_module_import
+   1_Test_Example/index
+


### PR DESCRIPTION
Closes #164 

Creates two example files that test the display-related functionality in the examples. These files go through the same process as the real examples but do not require a live Granta MI instance, so they run much quicker than the real examples.