### PR TITLE
Add client connection check

### DIFF
--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -323,11 +323,11 @@ class BomAnalyticsClient(ApiClient):
         ...
 
     @overload
-    def run(self, query: Yaml) -> str:
+    def run(self, query: "Yaml") -> str:
         ...
 
     @overload
-    def run(self, query: Type[Yaml]) -> str:
+    def run(self, query: Type["Yaml"]) -> str:
         ...
 
     def run(self, query):  # type: ignore[no-untyped-def]

--- a/src/ansys/grantami/bomanalytics/_connection.py
+++ b/src/ansys/grantami/bomanalytics/_connection.py
@@ -56,7 +56,6 @@ if TYPE_CHECKING:
         SubstanceComplianceQuery,
         BomImpactedSubstancesQuery,
         BomComplianceQuery,
-        Yaml,
     )
     from ._query_results import (
         MaterialImpactedSubstancesQueryResult,
@@ -324,11 +323,11 @@ class BomAnalyticsClient(ApiClient):
         ...
 
     @overload
-    def run(self, query: "Yaml") -> str:
+    def run(self, query: Yaml) -> str:
         ...
 
     @overload
-    def run(self, query: Type["Yaml"]) -> str:
+    def run(self, query: Type[Yaml]) -> str:
         ...
 
     def run(self, query):  # type: ignore[no-untyped-def]

--- a/src/ansys/grantami/bomanalytics/queries.py
+++ b/src/ansys/grantami/bomanalytics/queries.py
@@ -27,6 +27,7 @@ from typing import (
     Generator,
     Optional,
     Type,
+    TYPE_CHECKING,
 )
 import warnings
 from numbers import Number
@@ -41,9 +42,11 @@ from ._query_results import (
     ImpactedSubstancesBaseClass,
 )
 from .indicators import _Indicator, WatchListIndicator, RoHSIndicator
-from ._connection import Connection  # noqa: F401
 from ._exceptions import GrantaMIException
 from ._logger import logger
+
+if TYPE_CHECKING:
+    from ._connection import Connection  # noqa: F401
 
 Query_Builder = TypeVar("Query_Builder", covariant=True, bound=Union["_BaseQueryBuilder", "_ApiMixin"])
 Query_Result = TypeVar("Query_Result", covariant=True, bound=Union[ComplianceBaseClass, ImpactedSubstancesBaseClass])


### PR DESCRIPTION
Closes #215 

Adds a check as part of the `connect` method to perform a test query. The BoM Analytics service provides the Yaml endpoint which just returns the docs, so the test checks that this query can be performed without raising an exception.

If an exception is raised, then separate error messages are raised depending on whether it's a 404 (service not installed) or something else (probably a 500, check the service layer logs).