### PR TITLE
#236 - Publish Documentation to Dev Portal

### DIFF
--- a/.github/workflows/server_checks.yml
+++ b/.github/workflows/server_checks.yml
@@ -117,6 +117,40 @@ jobs:
       - name: Build PDF Documentation
         run: make -C doc latexpdf
 
+      - name: Build json documentation
+        run: |
+          # Export the documentation files to JSON files.
+          poetry run sphinx-build -M json doc/source doc-json -j auto -w build_errors.txt -N;
+        env:
+          TEST_SL_URL: ${{secrets.TEST_SERVER_URL}}
+          TEST_USER: ${{secrets.TEST_SERVER_READ_USER}}
+          TEST_PASS: ${{secrets.TEST_SERVER_READ_PASS}}
+          BUILD_EXAMPLES: 1
+
+      - name: Flatten the generated nested files into a single directory
+        run: |
+          echo Flattening a nested directory
+          mkdir doc-flatten-json;
+          echo Move all the JSON file to the flatten directory.
+          find . -name "*.fjson" -exec mv "{}" --backup=numbered ./doc-flatten-json \;
+          echo Make sure all the file has .json extensions instead of the .fjson
+          for file in doc-flatten-json/*.fjson ; do mv -- "$file" "${file%.fjson}.json" ; done;
+
+      - name: zip the flattened JSON directory
+        run: |
+          zip -r grantami-bomanalytics-doc-flatten-json.zip doc-flatten-json;
+          mkdir grantami-bomanalytics-doc-flatten-json;
+          mv grantami-bomanalytics-doc-flatten-json.zip grantami-bomanalytics-doc-flatten-json;
+          echo "Clean up build directories after the process is completed."
+          rm -rf doc-json doc-flatten-json;
+
+      - name: Upload json Documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: grantami-bomanalytics-doc-flatten-json.zip
+          path: grantami-bomanalytics-doc-flatten-json
+          retention-days: 7
+
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Closes #236 

This PR adds the documentation build and packaging steps for the dev portal. Does not currently push those changes to the appropriate branch for publishing, but stores them as a build artefact.

Based on work in https://github.com/pyansys/pyaedt/pull/1747/files