### PR TITLE
Docs - Remove sphinx_autodoc_typehints dependency

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,7 +23,6 @@ release = version = __version__
 # -- General configuration ---------------------------------------------------
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx_autodoc_typehints',
     'numpydoc',
     'sphinx.ext.doctest',
     'sphinx.ext.autosummary',
@@ -36,9 +35,15 @@ extensions = [
     "nbsphinx",
 ]
 
+# sphinx
 add_module_names = False
-typehints_fully_qualified = True
-typehints_document_rtype = False
+
+# sphinx.ext.autodoc
+autodoc_typehints = "description"
+autodoc_typehints_description_target = "documented"
+autodoc_type_aliases = {
+    "Yaml": "Yaml"
+}
 
 # Intersphinx mapping
 intersphinx_mapping = {

--- a/poetry.lock
+++ b/poetry.lock
@@ -1933,7 +1933,7 @@ examples = ["lxml", "tabulate", "pandas", "jupyterlab"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "8e53cc9d9c2b8b8750de6d69b4f47165f713c8da419e893e1fefc2f262d30dea"
+content-hash = "8fb5e9e05393bb70a20576f1681f89f8aa1b4114b2a5337303162973421334fa"
 
 [metadata.files]
 alabaster = [
@@ -2694,6 +2694,8 @@ psutil = [
     {file = "psutil-5.9.4-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:54d5b184728298f2ca8567bf83c422b706200bcbbfafdc06718264f9393cfeb7"},
     {file = "psutil-5.9.4-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:16653106f3b59386ffe10e0bad3bb6299e169d5327d3f187614b1cb8f24cf2e1"},
     {file = "psutil-5.9.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54c0d3d8e0078b7666984e11b12b88af2db11d11249a8ac8920dd5ef68a66e08"},
+    {file = "psutil-5.9.4-cp36-abi3-win32.whl", hash = "sha256:149555f59a69b33f056ba1c4eb22bb7bf24332ce631c44a319cec09f876aaeff"},
+    {file = "psutil-5.9.4-cp36-abi3-win_amd64.whl", hash = "sha256:fd8522436a6ada7b4aad6638662966de0d61d241cb821239b2ae7013d41a43d4"},
     {file = "psutil-5.9.4-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:6001c809253a29599bc0dfd5179d9f8a5779f9dffea1da0f13c53ee568115e1e"},
     {file = "psutil-5.9.4.tar.gz", hash = "sha256:3d7f9739eb435d4b1338944abe23f49584bde5395f27487d2ee25ad9a8774a62"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ optional = true
 ansys-sphinx-theme = { version = "0.7.1" }
 numpydoc = { version = "1.5.0" }
 sphinx = { version = "4.5.0" }
-sphinx_autodoc_typehints = { version = "1.19.1" }
 sphinx-notfound-page = { version = "0.8.3" }
 sphinx-copybutton = { version = "0.5.1" }
 enum_tools = { version = "0.9.0.post1" }


### PR DESCRIPTION
This PR removes the dependency on sphinx_autodoc_typehints. It was only used for removing typehints from signatures in the docs, which is now achieved by sphinx.ext.autodoc
Uses `autodoc_type_aliases` to prevent the fully qualified name of `Yaml` to be output.