### PR TITLE
Revert black formatting on example scripts

### DIFF
--- a/.github/workflows/local_checks.yml
+++ b/.github/workflows/local_checks.yml
@@ -9,13 +9,23 @@ env:
 
 jobs:
   style:
-    name: Code style
+    name: Code Style Check
     runs-on: ubuntu-latest
+
     steps:
-      - name: PyAnsys code style checks
-        uses: pyansys/actions/code-style@v2
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install style requirements
+        run: pip install 'tox<4' poetry --disable-pip-version-check
+
+      - name: Spell, Lint and Type Check
+        run: tox -e style
+
 
   docs-style:
     name: Documentation Style Check

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -235,12 +235,8 @@ def _copy_examples_and_convert_to_notebooks(source_dir, output_dir):
             file_output_path = root_output_path / Path(file)
             shutil.copy(file_source_path, file_output_path)  # Copy everything
             if file_source_path.suffix == ".py":  # Also convert python scripts to jupyter notebooks
-                notebook = jupytext.read(file_source_path)
-
-                # Filter out cells to remove
-                notebook.cells = [c for c in notebook.cells if "remove_cell" not in c.metadata.get("tags", [])]
-
-                jupytext.write(notebook, file_output_path.with_suffix(".ipynb"))
+                ntbk = jupytext.read(file_source_path)
+                jupytext.write(ntbk, file_output_path.with_suffix(".ipynb"))
 
 
 # If we already have a source/examples directory then don't do anything.

--- a/examples/0_Getting_started.py
+++ b/examples/0_Getting_started.py
@@ -92,19 +92,9 @@ query
 # Fluent interfaces are designed to allow a complex object to be constructed in a single line of code. As such, you can
 # consolidate the cells above into a single step:
 
-# + tags=["remove_cell"]
-# Turn off black formatting
-# fmt: off
-# -
-
 # + tags=[]
 query = queries.MaterialImpactedSubstancesQuery().with_material_ids(["plastic-abs-high-impact"]).with_legislations(["REACH - The Candidate List"])  # noqa: E501
 query
-# -
-
-# + tags=["remove_cell"]
-# Turn on black formatting
-# fmt: on
 # -
 
 # Because the fluent interface can produce very long lines of code, it's necessary to break your query creation code

--- a/examples/1_Impacted_Substances_Queries/1-1_Materials_impacted_substances.py
+++ b/examples/1_Impacted_Substances_Queries/1-1_Materials_impacted_substances.py
@@ -52,7 +52,9 @@ REACH = "REACH - The Candidate List"
 from ansys.grantami.bomanalytics import queries
 
 mat_query = (
-    queries.MaterialImpactedSubstancesQuery().with_material_ids([PPS_ID, PC_ID]).with_legislations([REACH, SIN_LIST])
+    queries.MaterialImpactedSubstancesQuery()
+    .with_material_ids([PPS_ID, PC_ID])
+    .with_legislations([REACH, SIN_LIST])
 )
 # -
 
@@ -90,9 +92,8 @@ for material in results.impacted_substances_by_material:
 # + tags=[]
 from tabulate import tabulate
 
-rows = [
-    (substance.cas_number, substance.max_percentage_amount_in_material) for substance in substances_by_material[PC_ID]
-]
+rows = [(substance.cas_number, substance.max_percentage_amount_in_material)
+    for substance in substances_by_material[PC_ID]]
 
 print(f'Substances impacted by "{SIN_LIST}" in "{PC_ID}" (10/{len(rows)})')
 print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
@@ -108,7 +109,8 @@ print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
 
 # + tags=[]
 material_substances_sin = results.impacted_substances_by_legislation[SIN_LIST]
-rows = [(substance.cas_number, substance.max_percentage_amount_in_material) for substance in material_substances_sin]
+rows = [(substance.cas_number, substance.max_percentage_amount_in_material)
+    for substance in material_substances_sin]
 print(f'Substances impacted by "{SIN_LIST}" in all materials (10/{len(rows)})')
 print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
 # -
@@ -124,7 +126,8 @@ print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
 
 # + tags=[]
 material_substances_all = results.impacted_substances
-rows = [(substance.cas_number, substance.max_percentage_amount_in_material) for substance in material_substances_all]
+rows = [(substance.cas_number, substance.max_percentage_amount_in_material)
+    for substance in material_substances_all]
 print(f"Impacted substances for all materials and legislations (10/{len(rows)})")
 print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
 # -

--- a/examples/1_Impacted_Substances_Queries/1-2_Parts_impacted_substances.py
+++ b/examples/1_Impacted_Substances_Queries/1-2_Parts_impacted_substances.py
@@ -62,7 +62,11 @@ REACH = "REACH - The Candidate List"
 # + tags=[]
 from ansys.grantami.bomanalytics import queries
 
-part_query = queries.PartImpactedSubstancesQuery().with_part_numbers([DRILL, WING]).with_legislations([SIN_LIST, REACH])
+part_query = (
+    queries.PartImpactedSubstancesQuery()
+    .with_part_numbers([DRILL, WING])
+    .with_legislations([SIN_LIST, REACH])
+)
 # -
 
 # Finally, run the query. Passing a ``PartImpactedSubstancesQuery`` object to the ``Connection.run()`` method returns a
@@ -98,7 +102,8 @@ for part in part_result.impacted_substances_by_part:
 # + tags=[]
 from tabulate import tabulate
 
-rows = [(substance.cas_number, substance.max_percentage_amount_in_material) for substance in substances_by_part[WING]]
+rows = [(substance.cas_number, substance.max_percentage_amount_in_material)
+        for substance in substances_by_part[WING]]
 
 print(f'Substances impacted by "{SIN_LIST}" in "{WING}"')
 print(tabulate(rows, headers=["CAS Number", "Amount (wt. %)"]))
@@ -114,7 +119,8 @@ print(tabulate(rows, headers=["CAS Number", "Amount (wt. %)"]))
 
 # + tags=[]
 part_substances_sin = part_result.impacted_substances_by_legislation[SIN_LIST]
-rows = [(substance.cas_number, substance.max_percentage_amount_in_material) for substance in part_substances_sin]
+rows = [(substance.cas_number, substance.max_percentage_amount_in_material)
+        for substance in part_substances_sin]
 print(f'Substances impacted by "{SIN_LIST}" in all parts (10/{len(rows)})')
 print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
 # -
@@ -130,7 +136,8 @@ print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
 
 # + tags=[]
 part_substances_all = part_result.impacted_substances
-rows = [(substance.cas_number, substance.max_percentage_amount_in_material) for substance in part_substances_all]
+rows = [(substance.cas_number, substance.max_percentage_amount_in_material)
+        for substance in part_substances_all]
 print(f'Impacted substances across all legislations in "DRILL" (10/{len(rows)})')
 print(tabulate(rows[:10], headers=["CAS Number", "Amount (wt. %)"]))
 # -

--- a/examples/2_Compliance_Queries/2-1_Substance_compliance.py
+++ b/examples/2_Compliance_Queries/2-1_Substance_compliance.py
@@ -54,7 +54,10 @@ svhc = indicators.WatchListIndicator(
     legislation_names=["REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
-sin = indicators.WatchListIndicator(name="SIN", legislation_names=["The SIN List 2.1 (Substitute It Now!)"])
+sin = indicators.WatchListIndicator(
+    name="SIN",
+    legislation_names=["The SIN List 2.1 (Substitute It Now!)"]
+)
 # -
 
 # + [markdown] tags=[]
@@ -70,9 +73,10 @@ sin = indicators.WatchListIndicator(name="SIN", legislation_names=["The SIN List
 from ansys.grantami.bomanalytics import queries
 
 sub_query = queries.SubstanceComplianceQuery().with_indicators([svhc, sin])
-sub_query = sub_query.with_cas_numbers_and_amounts(
-    [("50-00-0", 10), ("110-00-9", 25), ("302-17-0", 100), ("7440-23-5", 100)]
-)
+sub_query = sub_query.with_cas_numbers_and_amounts([("50-00-0", 10),
+                                                    ("110-00-9", 25),
+                                                    ("302-17-0", 100),
+                                                    ("7440-23-5", 100)])
 # -
 
 # Finally, run the query. Passing a ``SubstanceComplianceQuery`` object to the ``Connection.run()`` method returns a
@@ -104,7 +108,7 @@ non_compliant_substances = []
 threshold = svhc.available_flags.WatchListAboveThreshold
 
 for substance in sub_result.compliance_by_substance_and_indicator:
-    if substance.indicators["SVHC"] >= threshold:
+    if (substance.indicators["SVHC"] >= threshold):
         non_compliant_substances.append(substance)
     else:
         compliant_substances.append(substance)

--- a/examples/2_Compliance_Queries/2-2_Material_compliance.py
+++ b/examples/2_Compliance_Queries/2-2_Material_compliance.py
@@ -54,7 +54,10 @@ svhc = indicators.WatchListIndicator(
     legislation_names=["REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
-sin = indicators.WatchListIndicator(name="SIN", legislation_names=["The SIN List 2.1 (Substitute It Now!)"])
+sin = indicators.WatchListIndicator(
+    name="SIN",
+    legislation_names=["The SIN List 2.1 (Substitute It Now!)"]
+)
 # -
 
 # + [markdown] tags=[]
@@ -69,9 +72,9 @@ sin = indicators.WatchListIndicator(name="SIN", legislation_names=["The SIN List
 from ansys.grantami.bomanalytics import queries
 
 mat_query = queries.MaterialComplianceQuery().with_indicators([svhc, sin])
-mat_query = mat_query.with_material_ids(
-    ["plastic-pa66-60glassfiber", "zinc-pb-cdlow-alloy-z21220-rolled", "stainless-316h"]
-)
+mat_query = mat_query.with_material_ids(["plastic-pa66-60glassfiber",
+                                         "zinc-pb-cdlow-alloy-z21220-rolled",
+                                         "stainless-316h"])
 # -
 
 # Finally, run the query. Passing a ``MaterialComplianceQuery`` object to the ``Connection.run()`` method returns a
@@ -113,7 +116,9 @@ print(f"PA66 (60% glass fiber): {pa_66.indicators['SVHC'].flag.name}")
 
 # + tags=[]
 above_threshold_flag = svhc.available_flags.WatchListAboveThreshold
-pa_66_svhcs = [sub for sub in pa_66.substances if sub.indicators["SVHC"] >= above_threshold_flag]
+pa_66_svhcs = [sub for sub in pa_66.substances
+               if sub.indicators["SVHC"] >= above_threshold_flag
+               ]
 print(f"{len(pa_66_svhcs)} SVHCs")
 for sub in pa_66_svhcs:
     print(f"Substance record history identity: {sub.record_history_identity}")
@@ -137,10 +142,13 @@ print(f"Zn-Pb-Cd low alloy: {zn_pb_cd.indicators['SVHC'].flag.name}")
 
 # + tags=[]
 below_threshold_flag = svhc.available_flags.WatchListBelowThreshold
-zn_svhcs_below_threshold = [sub for sub in zn_pb_cd.substances if sub.indicators["SVHC"].flag == below_threshold_flag]
+zn_svhcs_below_threshold = [sub for sub in zn_pb_cd.substances
+                            if sub.indicators["SVHC"].flag == below_threshold_flag]
 print(f"{len(zn_svhcs_below_threshold)} SVHCs below threshold")
 for substance in zn_svhcs_below_threshold:
-    print(f"Substance record history identity: {substance.record_history_identity}")
+    print(
+        f"Substance record history identity: {substance.record_history_identity}"
+    )
 # -
 
 # Finally, look at the stainless steel record.
@@ -157,7 +165,11 @@ print(f"316H stainless steel: {ss_316h.indicators['SVHC'].flag.name}")
 
 # + tags=[]
 not_impacted_flag = svhc.available_flags.WatchListNotImpacted
-ss_not_impacted = [sub for sub in ss_316h.substances if sub.indicators["SVHC"].flag == not_impacted_flag]
+ss_not_impacted = [
+    sub
+    for sub in ss_316h.substances
+    if sub.indicators["SVHC"].flag == not_impacted_flag
+]
 print(f"{len(ss_not_impacted)} non-SVHC substances")
 for sub in ss_not_impacted:
     print(f"Substance record history identity: {sub.record_history_identity}")

--- a/examples/2_Compliance_Queries/2-3_Part_compliance.py
+++ b/examples/2_Compliance_Queries/2-3_Part_compliance.py
@@ -54,7 +54,10 @@ svhc = indicators.WatchListIndicator(
     legislation_names=["REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
-sin = indicators.WatchListIndicator(name="SIN", legislation_names=["The SIN List 2.1 (Substitute It Now!)"])
+sin = indicators.WatchListIndicator(
+    name="SIN",
+    legislation_names=["The SIN List 2.1 (Substitute It Now!)"]
+)
 # -
 
 # + [markdown] tags=[]
@@ -68,7 +71,11 @@ sin = indicators.WatchListIndicator(name="SIN", legislation_names=["The SIN List
 # + tags=[]
 from ansys.grantami.bomanalytics import queries
 
-part_query = queries.PartComplianceQuery().with_part_numbers(["asm_flap_mating", "DRILL"]).with_indicators([svhc])
+part_query = (
+    queries.PartComplianceQuery()
+    .with_part_numbers(["asm_flap_mating", "DRILL"])
+    .with_indicators([svhc])
+)
 # -
 
 # Finally, run the query. Passing a ``PartComplianceQuery`` object to the ``Connection.run()`` method returns a
@@ -116,7 +123,8 @@ print(f"Wing compliance status: {wing.indicators['SVHC'].flag.name}")
 
 # + tags=[]
 above_threshold_flag = svhc.available_flags.WatchListAboveThreshold
-parts_contain_svhcs = [part for part in wing.parts if part.indicators["SVHC"] >= above_threshold_flag]
+parts_contain_svhcs = [part for part in wing.parts
+                       if part.indicators["SVHC"] >= above_threshold_flag]
 print(f"{len(parts_contain_svhcs)} parts that contain SVHCs")
 for part in parts_contain_svhcs:
     print(f"Part: {part.record_history_identity}")
@@ -129,12 +137,11 @@ for part in parts_contain_svhcs:
 
 # + tags=[]
 def recursively_print_parts_with_svhcs(parts, depth=0):
-    parts_contain_svhcs = [part for part in parts if part.indicators["SVHC"] >= above_threshold_flag]
+    parts_contain_svhcs = [part for part in parts
+                           if part.indicators["SVHC"] >= above_threshold_flag]
     for part in parts_contain_svhcs:
         print(f"{'  '*depth}- Part: {part.record_history_identity}")
         recursively_print_parts_with_svhcs(part.parts, depth + 1)
-
-
 # -
 
 
@@ -148,59 +155,54 @@ recursively_print_parts_with_svhcs(wing.parts)
 
 # + tags=[]
 def recursively_print_parts_with_svhcs(parts, depth=0):
-    parts_contain_svhcs = [part for part in parts if part.indicators["SVHC"] >= above_threshold_flag]
+    parts_contain_svhcs = [part for part in parts
+                           if part.indicators["SVHC"] >= above_threshold_flag]
     for part in parts_contain_svhcs:
         print(f"{'  '*depth}- Part: {part.record_history_identity}")
         recursively_print_parts_with_svhcs(part.parts, depth + 1)
         print_materials_with_svhcs(part.materials, depth + 1)
         print_specifications_with_svhcs(part.specifications, depth + 1)
         print_substances_with_svhcs(part.substances, depth + 1)
-
-
 # -
 
 
 # + tags=[]
 def print_materials_with_svhcs(materials, depth=0):
-    mats_contain_svhcs = [m for m in materials if m.indicators["SVHC"] >= above_threshold_flag]
+    mats_contain_svhcs = [m for m in materials
+                          if m.indicators["SVHC"] >= above_threshold_flag]
     for mat in mats_contain_svhcs:
         print(f"{'  '*depth}- Material: {mat.record_history_identity}")
         print_substances_with_svhcs(mat.substances, depth + 1)
-
-
 # -
 
 
 # + tags=[]
 def print_specifications_with_svhcs(specifications, depth=0):
-    specs_contain_svhcs = [s for s in specifications if s.indicators["SVHC"] >= above_threshold_flag]
+    specs_contain_svhcs = [s for s in specifications
+                           if s.indicators["SVHC"] >= above_threshold_flag]
     for spec in specs_contain_svhcs:
         print(f"{'  '*depth}- Specification: {spec.record_history_identity}")
         print_coatings_with_svhcs(spec.coatings, depth + 1)
         print_substances_with_svhcs(spec.substances, depth + 1)
-
-
 # -
 
 
 # + tags=[]
 def print_coatings_with_svhcs(coatings, depth=0):
-    coatings_contain_svhcs = [c for c in coatings if c.indicators["SVHC"] >= above_threshold_flag]
+    coatings_contain_svhcs = [c for c in coatings
+                             if c.indicators["SVHC"] >= above_threshold_flag]
     for coating in coatings_contain_svhcs:
         print(f"{'  '*depth}- Coating: {coating.record_history_identity}")
         print_substances_with_svhcs(coating.substances, depth + 1)
-
-
 # -
 
 
 # + tags=[]
 def print_substances_with_svhcs(substances, depth=0):
-    subs_contain_svhcs = [sub for sub in substances if sub.indicators["SVHC"] >= above_threshold_flag]
+    subs_contain_svhcs = [sub for sub in substances
+                          if sub.indicators["SVHC"] >= above_threshold_flag]
     for sub in subs_contain_svhcs:
         print(f"{'  '*depth}- Substance: {sub.record_history_identity}")
-
-
 # -
 
 

--- a/examples/3_Advanced_Topics/3-1_Working_with_XML_BoMs.py
+++ b/examples/3_Advanced_Topics/3-1_Working_with_XML_BoMs.py
@@ -46,8 +46,6 @@ def xml_validator(xml: str, schema_file: str) -> bool:
     schema = etree.XMLSchema(file=schema_file)
     doc = etree.fromstring(xml)
     return schema.validate(doc)
-
-
 # -
 
 
@@ -67,7 +65,9 @@ result
 invalid_xml_file = "supporting-files/invalid-bom.xml"
 with open(invalid_xml_file) as f:
     invalid_xml = f.read()
-result = xml_validator(invalid_xml, "supporting-files/BillOfMaterialsEco.xsd")
+result = xml_validator(
+    invalid_xml, "supporting-files/BillOfMaterialsEco.xsd"
+)
 result
 # -
 
@@ -91,7 +91,11 @@ cxn = Connection(server_url).with_credentials("user_name", "password").connect()
 from ansys.grantami.bomanalytics import queries
 
 SIN_LIST = "The SIN List 2.1 (Substitute It Now!)"
-impacted_substances_query = queries.BomImpactedSubstancesQuery().with_bom(valid_xml).with_legislations([SIN_LIST])
+impacted_substances_query = (
+    queries.BomImpactedSubstancesQuery()
+    .with_bom(valid_xml)
+    .with_legislations([SIN_LIST])
+)
 # -
 
 # + tags=[]
@@ -127,7 +131,11 @@ svhc = indicators.WatchListIndicator(
     legislation_names=["REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
-compliance_query = queries.BomComplianceQuery().with_bom(valid_xml).with_indicators([svhc])
+compliance_query = (
+    queries.BomComplianceQuery()
+    .with_bom(valid_xml)
+    .with_indicators([svhc])
+)
 # -
 
 # + tags=[]
@@ -151,7 +159,11 @@ print(f"BoM Compliance Status: {root_part.indicators['SVHC'].flag.name}")
 # ``True``.
 
 # + tags=[]
-broken_query = queries.BomImpactedSubstancesQuery().with_bom(invalid_xml).with_legislations([SIN_LIST])
+broken_query = (
+    queries.BomImpactedSubstancesQuery()
+    .with_bom(invalid_xml)
+    .with_legislations([SIN_LIST])
+)
 
 RUN_QUERY = False
 

--- a/examples/3_Advanced_Topics/3-2_Dealing_with_external_data_sources.py
+++ b/examples/3_Advanced_Topics/3-2_Dealing_with_external_data_sources.py
@@ -81,7 +81,11 @@ svhc = indicators.WatchListIndicator(
     legislation_names=["REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
-mat_query = queries.MaterialComplianceQuery().with_indicators([svhc]).with_material_ids(material_ids)
+mat_query = (
+    queries.MaterialComplianceQuery()
+    .with_indicators([svhc])
+    .with_material_ids(material_ids)
+)
 mat_results = cxn.run(mat_query)
 mat_results
 # -
@@ -98,7 +102,8 @@ mat_results
 # To do this, first create a dictionary that maps a material ID to the indicator result returned by the query.
 
 # + tags=[]
-material_lookup = {mat.material_id: mat.indicators["SVHC"] for mat in mat_results.compliance_by_material_and_indicator}
+material_lookup = {mat.material_id: mat.indicators["SVHC"]
+                   for mat in mat_results.compliance_by_material_and_indicator}
 # -
 
 # Next, define a function that takes a list of material IDs and returns the worst compliance status associated with the
@@ -113,8 +118,6 @@ def rollup_results(material_ids) -> str:
     indicator_results = [material_lookup[mat_id] for mat_id in material_ids]
     worst_result = max(indicator_results)
     return worst_result.flag.name
-
-
 # -
 
 
@@ -122,7 +125,8 @@ def rollup_results(material_ids) -> str:
 # and compliance status.
 
 # + tags=[]
-component_results = {comp["part_number"]: rollup_results(comp["materials"]) for comp in components}
+component_results = {comp["part_number"]: rollup_results(comp["materials"])
+                     for comp in components}
 component_results
 # -
 
@@ -142,7 +146,8 @@ result_map = {
 # You can now use this dictionary to map from the Granta MI result to the approval requirements.
 
 # + tags=[]
-results = {part_number: result_map[result] for part_number, result in component_results.items()}
+results = {part_number: result_map[result]
+           for part_number, result in component_results.items()}
 results
 # -
 

--- a/examples/3_Advanced_Topics/3-4_Writing_compliance_results_to_a_dataframe.py
+++ b/examples/3_Advanced_Topics/3-4_Writing_compliance_results_to_a_dataframe.py
@@ -36,7 +36,11 @@ svhc = indicators.WatchListIndicator(
     legislation_names=["REACH - The Candidate List"],
     default_threshold_percentage=0.1,
 )
-part_query = queries.PartComplianceQuery().with_record_history_ids([565060]).with_indicators([svhc])
+part_query = (
+    queries.PartComplianceQuery()
+    .with_record_history_ids([565060])
+    .with_indicators([svhc])
+)
 part_result = cxn.run(part_query)
 # -
 
@@ -46,7 +50,10 @@ part_result = cxn.run(part_query)
 
 # + tags=[]
 for part in part_result.compliance_by_part_and_indicator[0].parts:
-    print(f"Part ID: {part.record_history_identity}, " f"Compliance: {part.indicators['SVHC'].flag}")
+    print(
+        f"Part ID: {part.record_history_identity}, "
+        f"Compliance: {part.indicators['SVHC'].flag}"
+    )
 # -
 
 # However, this structure makes it difficult to compare items at different levels. To do that, you want to flatten the
@@ -76,8 +83,6 @@ def create_dict(item, item_type, level, parent_id):
         "Level": level,
     }
     return row
-
-
 # -
 
 # To help with the flattening process, you also define a schema, which describes which child item types each item
@@ -129,20 +134,23 @@ def flatten_bom(root_part):
 
         # Add the child items to the stack
         if "Part" in child_items:
-            items_to_process.extend([(p, "Part", child_level, item_id) for p in item_object.parts])
+            items_to_process.extend([(p, "Part", child_level, item_id)
+                                     for p in item_object.parts])
         if "Specification" in child_items:
-            items_to_process.extend([(s, "Specification", child_level, item_id) for s in item_object.specifications])
+            items_to_process.extend([(s, "Specification", child_level, item_id)
+                                     for s in item_object.specifications])
         if "Material" in child_items:
-            items_to_process.extend([(m, "Material", child_level, item_id) for m in item_object.materials])
+            items_to_process.extend([(m, "Material", child_level, item_id)
+                                     for m in item_object.materials])
         if "Coating" in child_items:
-            items_to_process.extend([(c, "Coating", child_level, item_id) for c in item_object.coatings])
+            items_to_process.extend([(c, "Coating", child_level, item_id)
+                                     for c in item_object.coatings])
         if "Substance" in child_items:
-            items_to_process.extend([(s, "Substance", child_level, item_id) for s in item_object.substances])
+            items_to_process.extend([(s, "Substance", child_level, item_id)
+                                     for s in item_object.substances])
 
     # When the stack is empty, the while loop exists. Return the result list.
     return result
-
-
 # -
 
 


### PR DESCRIPTION
Revert the changes made by #251 to the example Python script formatting. These changes produced very long lines which render with scrollbars in the sphinx theme.

Also required CI changes to avoid build errors.