### PR TITLE
Reformat for new black version

### DIFF
--- a/src/ansys/grantami/bomanalytics/_item_results.py
+++ b/src/ansys/grantami/bomanalytics/_item_results.py
@@ -404,7 +404,6 @@ class ImpactedSubstancesResultMixin(mixin_base_class):
     def _create_impacted_substance(
         substance: models.CommonImpactedSubstance,
     ) -> ImpactedSubstance:
-
         """Create an ``ImpactedSubstance`` result object based on the corresponding object returned from the low-level
         API.
 


### PR DESCRIPTION
Black 23.x includes changes to the formatting rules, which is breaking CI. This change fixes a formatting error raised by Black 23.