### PR TITLE
CI - Create dependabot_approve.yml

### DIFF
--- a/.github/workflows/dependabot_approve.yml
+++ b/.github/workflows/dependabot_approve.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-approve
+on: pull_request_target
+permissions:
+  pull-requests: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Checking the author will prevent your Action run failing on non-Dependabot PRs
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.3.6
+      - uses: actions/checkout@v3
+      - name: Approve a PR if not already approved
+        run: |
+          gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL"
+          else echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR copies the dependabot-approve workflow from OpenAPI-Common.

Approves PRs by dependabot to reduce need for clicking, must still be reviewed and added the merge queue manually.