### PR TITLE
Fix pypi upload wheel path

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Upload to PyPI
         run: |
           pip install twine
-          twine upload --non-interactive --skip-existing ~/**/*.whl
+          twine upload --non-interactive --skip-existing dist/*.whl
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
1.1.3 release failed because the upload to pypi is misconfigured after the changes made in #276 