### PR TITLE
Fix for Poetry with Pydata-Sphinx-Theme

### DIFF
--- a/.github/workflows/local_checks.yml
+++ b/.github/workflows/local_checks.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Install library
         run: |
           pip install poetry --disable-pip-version-check
+          poetry config installer.modern-installation false
           poetry install --with doc
 
       - name: Build HTML Documentation


### PR DESCRIPTION
Set poetry installer.modern-installation to false for installs which include pydata-sphinx-theme. This
is needed due to incorrect metadata in the package, which poetry now started to complain about.

Instead of pinning package version, we can simply switch this setting until the metadata in the
pydata-sphinx-theme version we use is fixed (probably, >0.13.1).